### PR TITLE
Transmit location

### DIFF
--- a/App.js
+++ b/App.js
@@ -17,7 +17,7 @@ export default createStackNavigator({
 	LotSubmissionForm: { screen: LotSubmissionForm },
 	Account: { screen: Account }
 }, {
-	initialRouteName: 'Login',
+	initialRouteName: 'Signup',
 	navigationOptions: {
 		title: 'BayRide',
 		headerLeft: null,

--- a/components/LotSubmissionForm.js
+++ b/components/LotSubmissionForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { StyleSheet, ScrollView, View, Button, Text, Platform } from 'react-native';
 import { FormLabel, FormInput, FormValidationMessage } from 'react-native-elements';
+import { Location } from 'expo';
 import { signup } from '../fireMethods';
 import { store } from '../fire';
 import firebase from 'firebase';
@@ -52,7 +53,26 @@ export default class LotSubmissionForm extends Component {
       driverId: null
     });
 	}
-
+	
+	handleUseCurrentLocation = () => {
+		/**
+		 * location has this form:
+		 * 	   "location": Object {
+		 *		     "coords": Object {
+		 *		       "accuracy": 65,
+		 *		       "altitude": 9.289741516113281,
+		 *		       "altitudeAccuracy": 10,
+		 *		       "heading": -1,
+		 *		       "latitude": 40.70523666448243,
+		 *		       "longitude": -74.0134370542345,
+		 *		       "speed": -1,
+		 *		     },
+		 *		     "timestamp": 1534919691811.1948,
+		 *		   },
+		 */
+		let location = await Location.getCurrentPositionAsync({});
+		this.setState({ pickupLocation: location })
+	}
 
 	setScreenshotId =  (photoID) => {
 		this.setState({ screenshot: photoID });
@@ -90,6 +110,7 @@ export default class LotSubmissionForm extends Component {
 					placeholder="Please enter pickup location"
 						onChangeText={pickupLocation => this.setState({ pickupLocation })}
 					/>
+					<Button title="Use my current location for pick up" onPress={this.handleUseCurrentLocation} />
 					<FormLabel>Drop off Location</FormLabel>
 					<FormInput
 					placeholder="Please enter drop off location"

--- a/components/MainScreen.js
+++ b/components/MainScreen.js
@@ -2,11 +2,9 @@ import React, { Component } from 'react';
 import { MapView, Location, Permissions } from 'expo';
 import {  StyleSheet, View, Alert } from 'react-native';
 import { Button } from 'react-native-elements';
-import {store, auth} from '../fire';
+import { store, auth } from '../fire';
 import { Marker } from 'react-native-maps';
 import { firebase } from '@firebase/app';
-
-import { MapView, Constants, Location, Permissions } from 'expo';
 
 
 class MainScreen extends Component {
@@ -44,7 +42,49 @@ class MainScreen extends Component {
 						}
       });
 		});
+		console.log(">>>>>>>>>", this.state)
 	}
+
+
+	///////////
+	/**
+	 * 0. I left most of the old parkupied code in as comments. Most of it's just logic that we don't want
+	 * 		anymore, but it's so convoluted that I couldn't tell if it was important or not
+	 * 1. Is there a reason that we don't simply get current user, and set it's state location to location?
+	 * 		It seems that the location param is the location of the user.. Is that correct?
+	 * 2. Again, what is movingLocation vs. location?
+	 * 3. For that matter, what is 'origin'? It's just a string version of the location..
+	 * 4. 
+	 */
+	onRegionChangeComplete = async (location) => {
+		// Is there a reason that origin is set to a string??
+    let origin = `${location.latitude}, ${location.longitude}`;
+		// if (!this.state.showFinalAlert && !this.state.showMatch && !this.state.showNoPSAlert) 
+		this.setState({ movinglocation: origin });
+
+    // let matchingEmail = '';
+    let myLocation = '';
+    await store.collection('users').where('email', '==', auth.currentUser.email).get().then(allUsers => {
+      allUsers.forEach(user => {
+        const id = user.id;
+        //Updates your data with matched user email
+        // if (user.data().matches.email) matchingEmail = user.data().matches.email;
+        // myLocation = user.data().location;
+        store.collection('users').doc(id).update({ location: this.state.movinglocation })
+      })
+    })
+  //   if (matchingEmail) {
+  //     store.collection('users').where('email', '==', matchingEmail).get().then(allUsers => {
+  //       allUsers.forEach(user => {
+  //         const id = user.id;
+  //         //Updates your data with matched user email
+  //         firestore.collection('users').doc(id).update({ matches: { email: authcurrentUser.email, location: myLocation } })
+  //       })
+  //     })
+	// 	}
+	}
+	///////////
+
 
 	_getLocationAsync = async () => {
 		let { status } = await Permissions.askAsync(Permissions.LOCATION);
@@ -70,8 +110,10 @@ class MainScreen extends Component {
 		this.setState({showBid: false});
 	}
 
-  render(){
-    const { marker, showBid, driverId, offer} = this.state;
+  render() {
+		const { marker, showBid, driverId, offer} = this.state;
+		console.log(">>>>>>>>>", this.state)
+
     return(
       <View style={styles.container}>
 			<MapView
@@ -82,8 +124,10 @@ class MainScreen extends Component {
         {marker.latitude ? <Marker
           coordinate={marker}
         /> : null}
-			</MapView>
+			></MapView>
 
+					{/** We can't do these alerts won't work as they are. I believe the problem is that the component is re-rendering
+								frequently, and every time it does, a new alert is sent.*/}
 					{showBid ? Alert.alert(
 						`New Bid! ${driverId} has bid ${offer}!`,
 						'Sound Good?',

--- a/components/MainScreen.js
+++ b/components/MainScreen.js
@@ -56,34 +56,34 @@ class MainScreen extends Component {
 	 * 3. For that matter, what is 'origin'? It's just a string version of the location..
 	 * 4. What's the difference (or at least difference in purpose) between onRegionChangeComplete and _getLocationAsync?
 	 */
-	onRegionChangeComplete = async (location) => {
-		// Is there a reason that origin is set to a string??
-    let origin = `${location.latitude}, ${location.longitude}`;
-		// if (!this.state.showFinalAlert && !this.state.showMatch && !this.state.showNoPSAlert) 
-		this.setState({ movinglocation: origin });
+	// onRegionChangeComplete = async (location) => {
+	// 	// Is there a reason that origin is set to a string??
+  //   let origin = `${location.latitude}, ${location.longitude}`;
+	// 	// if (!this.state.showFinalAlert && !this.state.showMatch && !this.state.showNoPSAlert) 
+	// 	this.setState({ movinglocation: origin });
 
-    // let matchingEmail = '';
-    let myLocation = '';
-    await store.collection('users').where('email', '==', auth.currentUser.email).get().then(allUsers => {
-      allUsers.forEach(user => {
-        const id = user.id;
-        //Updates your data with matched user email
-        // if (user.data().matches.email) matchingEmail = user.data().matches.email;
-        // myLocation = user.data().location;
-        store.collection('users').doc(id).update({ location: this.state.movinglocation })
-      })
-    })
-  //   if (matchingEmail) {
-  //     store.collection('users').where('email', '==', matchingEmail).get().then(allUsers => {
-  //       allUsers.forEach(user => {
-  //         const id = user.id;
-  //         //Updates your data with matched user email
-  //         firestore.collection('users').doc(id).update({ matches: { email: authcurrentUser.email, location: myLocation } })
-  //       })
+  //   // let matchingEmail = '';
+  //   let myLocation = '';
+  //   await store.collection('users').where('email', '==', auth.currentUser.email).get().then(allUsers => {
+  //     allUsers.forEach(user => {
+  //       const id = user.id;
+  //       //Updates your data with matched user email
+  //       // if (user.data().matches.email) matchingEmail = user.data().matches.email;
+  //       // myLocation = user.data().location;
+  //       store.collection('users').doc(id).update({ location: this.state.movinglocation })
   //     })
-	// 	}
-	}
-	///////////
+  //   })
+  // //   if (matchingEmail) {
+  // //     store.collection('users').where('email', '==', matchingEmail).get().then(allUsers => {
+  // //       allUsers.forEach(user => {
+  // //         const id = user.id;
+  // //         //Updates your data with matched user email
+  // //         firestore.collection('users').doc(id).update({ matches: { email: authcurrentUser.email, location: myLocation } })
+  // //       })
+  // //     })
+	// // 	}
+	// }
+	// ///////////
 
 
 	_getLocationAsync = async () => {

--- a/components/MainScreen.js
+++ b/components/MainScreen.js
@@ -54,7 +54,7 @@ class MainScreen extends Component {
 	 * 		It seems that the location param is the location of the user.. Is that correct?
 	 * 2. Again, what is movingLocation vs. location?
 	 * 3. For that matter, what is 'origin'? It's just a string version of the location..
-	 * 4. 
+	 * 4. What's the difference (or at least difference in purpose) between onRegionChangeComplete and _getLocationAsync?
 	 */
 	onRegionChangeComplete = async (location) => {
 		// Is there a reason that origin is set to a string??

--- a/components/MainScreen.js
+++ b/components/MainScreen.js
@@ -6,6 +6,9 @@ import {store, auth} from '../fire';
 import { Marker } from 'react-native-maps';
 import { firebase } from '@firebase/app';
 
+import { MapView, Constants, Location, Permissions } from 'expo';
+
+
 class MainScreen extends Component {
 
   state = {

--- a/components/Signup.js
+++ b/components/Signup.js
@@ -23,7 +23,7 @@ export default class Signup extends Component {
 		if (typeof result === 'string') {
 			this.setState({ response: result });
 		} else {
-			this.props.navigation.navigate('PassengerHome');
+			this.props.navigation.navigate('DrawerNavigator');
 		}
 	}
 

--- a/fireMethods/index.js
+++ b/fireMethods/index.js
@@ -23,6 +23,7 @@ async function signup (name, phone, email, password) {
 		phone,
 		email,
 		password,
+		location: [],
 		defaultSetting: "passenger",
 		paymentInformation: {},
 		drivingInformation: { canDrive: false }


### PR DESCRIPTION
# Don't merge this pull request, until we've talked about it # 
Changes have been made to MainScreen, such that it now talks to firestore, and to LotSubmissionForm, such that it allows a user to submit their current location as the pickup location.
We need to talk about what form the location should take (I think an object with just lat and long keys makes sense) and what code we can get rid of.