### PR TITLE
changed user IDs to be their emails

### DIFF
--- a/components/Account.js
+++ b/components/Account.js
@@ -29,7 +29,8 @@ export default class Account extends Component {
     }
 
 	handleSubmit = async () => {
-        console.log("This is where the edits should happen. (Nothing happens yet).")
+        console.log("This is where the edits should happen. (Nothing happens yet).");
+        console.log("Please note: We can't just let users edit their emails... Important to talk about this");
 	}
 
 	render() {
@@ -37,6 +38,7 @@ export default class Account extends Component {
 		return (
 			<View>
                 <Text>This is your profile!!</Text>
+                <Text>Please note: We can't just let users edit their emails... Important to talk about this</Text>
                 <Text>Name: </Text>
                 <Text>{name}</Text>
                 <Text>email: </Text>

--- a/fireMethods/index.js
+++ b/fireMethods/index.js
@@ -18,7 +18,7 @@ async function signup (name, phone, email, password) {
 	if (res) return res;
 
 	// DB Signup
-	await store.collection("users").add({
+	await store.collection("users").doc(email).set({
 		name,
 		phone,
 		email,


### PR DESCRIPTION
This should be a relatively simple optimization..
When a user signs up, their ID will be their email (current users of course still have the firestore-generated IDs). This is okay, because emails are unique.
This will allow us to look up the current user in constant time, whereas before it had been linear time. 
***Please Note: The only update has been to users being signed in, and none of the queries have been changed. We can just update them as we see them, and hopefully this way will be easier for us to make changes. Also note: please test these changes 😄***

------------------
The query will look like this:
------------------
        store.collection("users").doc(auth.currentUser.email).get()
        .then(user => {
                this.setState({name: user.data().name, email: user.data().email, id: user.id})
        })
------------------
rather than like this
------------------
        store.collection("users").where("email", "==", auth.currentUser.email).get()
        .then(users => {
            users.forEach(user => {
                this.setState({name: user.data().name, email: user.data().email, id: user.id})
            })
        })
------------------
------------------

For the Account.js page..
Please note: We can't just let users edit their emails... Important to talk about how we want this to work, how much freedom they should be able to have, etc.