### PR TITLE
More match banner improvements

### DIFF
--- a/components/Account.js
+++ b/components/Account.js
@@ -92,7 +92,7 @@ export default class Account extends Component {
 						<Text>Sign up to drive and start earning!!</Text>
 						<Text>BayRide puts the control back in the hands of the drivers.</Text><Button rounded info onPress={() => {
 							// Please note: we can assume that the user, right here, is a Passenger, and not a driver, because canDrive is false
-							if (this.state.user.currentLot) { // the user has a lot currently open
+							if (this.state.user.currentLot.lotId) { // the user has a lot currently open
 								this.setState({ showAlert: true })
 							} else { // The user does not have a lot currently open
 								this.props.navigation.navigate('DriverRegistration')

--- a/components/DriverHome.js
+++ b/components/DriverHome.js
@@ -26,14 +26,14 @@ export default class DriverHome extends Component {
 			});
 		});
 
-    let myCurrentLot;
+    let myCurrentLotId;
     store.collection("users").doc(auth.currentUser.email).get().then(user => {
-      myCurrentLot = user.data().currentLot;
+      myCurrentLotId = user.data().currentLot.lotId;
     })
     /**
      * So what this means is that Winning can only happen if the component mounts
      */
-		// Also, we can make do this better by simply checking if `myCurrentlot` exists in lot_history.. If it does, then winner
+		// Also, we can make do this better by simply checking if `myCurrentlotId` exists in lot_history.. If it does, then winner
 		// OR REALLY, can't we just navigate there when a lot expires...
 		/**
 		 * Actually, we should do both.. 
@@ -42,7 +42,7 @@ export default class DriverHome extends Component {
 		 */
     await store.collection('lot_history').where('driverId', '==', auth.currentUser.email).get().then(lots => {
       lots.forEach(lot => { // Please note: linear queries, such as this one, are bad
-        if (lot.id === myCurrentLot) {
+        if (lot.id === myCurrentLotId) {
           this.setState({ winningId: lot.id });
         }
       });

--- a/components/LotBanner.js
+++ b/components/LotBanner.js
@@ -41,7 +41,7 @@ export default class LotBanner extends React.Component {
 
 	handlePress = async () => {
 		let driverExpoToken;
-		store.collection("users").doc(auth.currentUser.email).update({ currentLot: this.state.lotData.lotId });
+		store.collection("users").doc(auth.currentUser.email).update({ "currentLot.lotId" : this.state.lotData.lotId });
 		await store.collection("users").doc(auth.currentUser.email).get().then(user => {
 			driverExpoToken = user.data().expoToken;
 		})

--- a/components/LotBannerWrapper.js
+++ b/components/LotBannerWrapper.js
@@ -21,9 +21,9 @@ export default class LotBannerWrapper extends Component {
 		/**
 		 * Please note: It is very important the order in which we do this.. This query must happen before we expire the lot (Also, the below is not actually fixed...)
 		 */
-		let myCurrentLot;
+		let myCurrentLotId;
 		await store.collection("users").doc(auth.currentUser.email).get().then(user => {
-			myCurrentLot = user.data().currentLot;
+			myCurrentLotId = user.data().currentLot.lotId;
 		});
 
 		/** 
@@ -46,8 +46,8 @@ export default class LotBannerWrapper extends Component {
 		if (!newLotId) { return "The lot was already taken care of"; }
 		// ^^ So do we even need this? I don't think so...
 
-		if (myCurrentLot === expiringLotId) {
-			store.collection("users").doc(auth.currentUser.email).update({ currentLot: newLotId }); // I don't think that this is right... Won't this mean that anyone on DriverHome will have their currentLot set to the new Lot id?
+		if (myCurrentLotId === expiringLotId) {
+			store.collection("users").doc(auth.currentUser.email).update({ "currentLot.lotId" : newLotId }); // I don't think that this is right... Won't this mean that anyone on DriverHome will have their currentLot set to the new Lot id?
 			// Here's where, if you're the winner, we navigate you to Winner.js
 			this.props.navigation.navigate('Winner');
 			// How do we do that? Does this.props.navigation.navigate('Winner') work? Even though LBW isn't in DrawerNavigator?

--- a/components/LotBannerWrapper.js
+++ b/components/LotBannerWrapper.js
@@ -18,6 +18,13 @@ export default class LotBannerWrapper extends Component {
 		this.setState({ showThisBanner: false });
 		this.props.navigation.navigate('Winner');
 
+		/**
+		 * Please note: It is very important the order in which we do this.. This query must happen before we expire the lot (Also, the below is not actually fixed...)
+		 */
+		let myCurrentLot;
+		await store.collection("users").doc(auth.currentUser.email).get().then(user => {
+			myCurrentLot = user.data().currentLot;
+		});
 
 		/** 
 		 * In reality, basically nothing below this should be here, because the only thing that we want to happen for every user who is viewing the app is for the lot to disappear when time's up..
@@ -38,12 +45,6 @@ export default class LotBannerWrapper extends Component {
 		// This should be the case where no one was the  no one was the driver
 		if (!newLotId) { return "The lot was already taken care of"; }
 		// ^^ So do we even need this? I don't think so...
-
-		// Not this..
-		let myCurrentLot;
-		store.collection("users").doc(auth.currentUser.email).get().then(user => {
-			myCurrentLot = user.data().currentLot;
-		});
 
 		if (myCurrentLot === expiringLotId) {
 			store.collection("users").doc(auth.currentUser.email).update({ currentLot: newLotId }); // I don't think that this is right... Won't this mean that anyone on DriverHome will have their currentLot set to the new Lot id?

--- a/components/LotSubmissionForm.js
+++ b/components/LotSubmissionForm.js
@@ -35,7 +35,7 @@ export default class LotSubmissionForm extends Component {
 			this.state.offer,
 			carType);
 		// The below line updates the user and then this update can be read from the componentDidMount in MainScreen
-		store.collection("users").doc(auth.currentUser.email).update({ currentLot: lotId });
+		store.collection("users").doc(auth.currentUser.email).update({ "currentLot.lotId" : lotId });
 		this.props.navigation.navigate('MainScreen'); // Should this go first?? Will it make it a faster, smoother user experience? IE: you're navigating to MainScreen immediately, and while that's happening, the request is being fulfilled
 	}
 

--- a/components/MainScreen.js
+++ b/components/MainScreen.js
@@ -22,7 +22,7 @@ export default class MainScreen extends Component {
 		offer: '',
 		driverId: '', // This should be driver's name, not id, which is an email
 		matchBanner: false, // This is the Bool which determines whether or not we display the MatchBanner modal component thing, which shows the status of the trip you want to take
-		currentLot: '', // This is the id of the lot that passenger has open
+		currentLotId: '', // This is the id of the lot that passenger has open
 		showReceipt: false, // this determines whether or not to display the receipt of the passenger's most recent trip (remember, this should only happen the first time).
 
 	}
@@ -51,7 +51,7 @@ export default class MainScreen extends Component {
 		// Now it also makes sure that the receipt displays properly
 		let myPassengerLotHistory, mostRecentLotId;
         await store.collection("users").doc(auth.currentUser.email).get().then(user => {
-			this.setState({ currentLot: user.data().currentLot })
+			this.setState({ currentLotId: user.data().currentLot.lotId })
             myPassengerLotHistory = user.data().myPassengerLotHistory
         });
         await store.collection("passenger_lot_history").doc(myPassengerLotHistory).get().then(plh => {
@@ -153,7 +153,7 @@ export default class MainScreen extends Component {
 				) : null}
 
 
-				{!!this.state.currentLot
+				{!!this.state.currentLotId
 				? 	<View style={style.matchMain}>
 						<Button rounded info onPress={() => this.setState({matchBanner: true})}>
 							<Text style={style.buttonText} >View your current trip</Text>
@@ -165,7 +165,7 @@ export default class MainScreen extends Component {
 						</Button>
 					</View> }
 
-				{this.state.matchBanner ? <MatchBanner currentLot={this.state.currentLot} close={() => this.setState({ matchBanner: false })} delete={() => this.setState({ currentLot: '' })}  /> : null}
+				{this.state.matchBanner ? <MatchBanner currentLotId={this.state.currentLotId} close={() => this.setState({ matchBanner: false })} delete={() => this.setState({ currentLotId: '' })}  /> : null}
 				{this.state.showReceipt ? <TripReceipt close={this.handleCloseReceipt}  /> : null}
 			</View>
 		);

--- a/components/MatchBanner.js
+++ b/components/MatchBanner.js
@@ -19,12 +19,12 @@ export default class MatchBanner extends React.Component {
 	}
 
 	async componentDidMount () {
-		await store.collection("lots").doc(this.props.currentLot).get().then(lot => {
+		await store.collection("lots").doc(this.props.currentLotId).get().then(lot => {
 			this.setState({ lotData: lot.data() });
 		});
 		if (this.state.lotData.driverId) {
 			store.collection("users").doc(this.state.lotData.driverId).get().then(driver => {
-				this.setState({ driverInfo: driver.data()});
+				this.setState({ driverInfo: driver.data() });
 			});
 		}
 	}
@@ -32,8 +32,8 @@ export default class MatchBanner extends React.Component {
 	handleDelete = async () => {
 		this.props.close();
 		// actually delete the lot from the db
-		expireLot(this.props.currentLot);
-		store.collection("users").doc(auth.currentUser.email).update({ currentLot: '' });
+		expireLot(this.props.currentLotId);
+		store.collection("users").doc(auth.currentUser.email).update({ "currentLot.lotId" : '' });
 		// Also, do we need to further update the state of MainScreen?
 		this.props.delete(); // Yes, this
 	}

--- a/components/MatchBanner.js
+++ b/components/MatchBanner.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 import { Button, Text } from 'native-base';
-import { store } from '../fire';
+import { store, auth } from '../fire';
 import TimerCountdown from 'react-native-timer-countdown';
 import Modal from 'react-native-modal';
 import call from 'react-native-phone-call';
@@ -29,10 +29,11 @@ export default class MatchBanner extends React.Component {
 		}
 	}
 
-	handleDelete = () => {
+	handleDelete = async () => {
 		this.props.close();
 		// actually delete the lot from the db
 		expireLot(this.props.currentLot);
+		store.collection("users").doc(auth.currentUser.email).update({ currentLot: '' });
 		// Also, do we need to further update the state of MainScreen?
 		this.props.delete(); // Yes, this
 	}
@@ -72,6 +73,7 @@ export default class MatchBanner extends React.Component {
 							<Button rounded info onPress={() => this.props.close()}>
 								<Text>Close</Text>
 							</Button>
+							<Text>  </Text>
 							{this.state.lotData.driverId
 							?	null
 							:	<Button rounded info onPress={this.handleDelete}>

--- a/components/MatchBanner.js
+++ b/components/MatchBanner.js
@@ -68,14 +68,14 @@ export default class MatchBanner extends React.Component {
 						: <Text>No one has submitted a bid yet, but be patient</Text>
 						}
 
-						<View> {/** Can we style this view, so that these buttons are in a row */}
+						<View style={style.buttonRows} > {/** Can we style this view, so that these buttons are in a row */}
 							<Button rounded info onPress={() => this.props.close()}>
 								<Text>Close</Text>
 							</Button>
 							{this.state.lotData.driverId
 							?	null
 							:	<Button rounded info onPress={this.handleDelete}>
-									<Text>Delte this Ride</Text>
+									<Text>Delete this Ride</Text>
 								</Button>
 							}
 						</View>

--- a/components/SideMenu.js
+++ b/components/SideMenu.js
@@ -79,7 +79,7 @@ export default class SideMenu extends Component {
 				<View>
 					<Button full info style={style.navItemStyleSM} onPress={this.handleHome}><Text style={style.navItemTextSM} >HOME</Text></Button>
 					<Button full info style={style.navItemStyleSM} onPress={this.navigateToScreen('Account')}><Text style={style.navItemTextSM} >MY ACCOUNT</Text></Button>
-					{this.state.currentLot ? null : switchButton }
+					{this.state.currentLot.lotId ? null : switchButton }
 					<Button full info style={style.navItemStyleSM} onPress={this.navigateToScreen('Payment')}><Text style={style.navItemTextSM} >PAYMENT</Text></Button>
 
 					<Button full info style={style.navItemStyleSM} onPress={this.navigateToScreen('History')}><Text style={style.navItemTextSM} >HISTORY</Text></Button>
@@ -88,7 +88,7 @@ export default class SideMenu extends Component {
 
 					<Button full info style={style.navItemStyleSM} onPress={this.navigateToScreen('Help')}><Text style={style.navItemTextSM} >HELP</Text></Button>
 
-					{this.state.currentLot ? null : <Button full info style={style.navItemStyleSM} onPress={this.handleLogout}><Text style={style.navItemTextSM} >LOG OUT</Text></Button> }
+					{this.state.currentLot.lotId ? null : <Button full info style={style.navItemStyleSM} onPress={this.handleLogout}><Text style={style.navItemTextSM} >LOG OUT</Text></Button> }
 
 				</View>
 				<View style={style.footerContainerSM}>

--- a/components/Winner.js
+++ b/components/Winner.js
@@ -33,7 +33,7 @@ export default class Winner extends React.Component {
 		let lotId;
 		await store.collection("users").doc(auth.currentUser.email).get().then(user => {
 			// Since the ride is not complete, then we can find the lotId (which links to a lot_history doc), as currentLot on the user
-			lotid = user.data().currentLot;
+			lotid = user.data().currentLot.lotId;
 		});
 		await store.collection("lot_history").doc(lotId).get().then(lot => {
 			this.setState({ lot: lot.data() });
@@ -94,8 +94,8 @@ export default class Winner extends React.Component {
 	}
 
 	handleFinishTrip () {
-		store.collection("users").doc(auth.currentUser.email).update({ currentLot: '' });
-		store.collection("users").doc(this.state.lot.passengerId).update({ currentLot: '' });
+		store.collection("users").doc(auth.currentUser.email).update({ "currentLot.lotId" : '' });
+		store.collection("users").doc(this.state.lot.passengerId).update({ "currentLot.lotId" : '' });
 		// Update the lot_history, so that showReceipt is true
 		store.collection("lot_history").doc(this.state.lot.lotId).update({ showReceipt: true })
 		this.props.navigation.navigate('DriverHome');

--- a/fireMethods/index.js
+++ b/fireMethods/index.js
@@ -43,7 +43,10 @@ async function signup (name, phone, email, password) {
 		password,
 		location: [],
 		currentlyPassenger: true,
-		currentLot: '', // Having just this one means that it is important that passengers don't bid on their own lots in testing
+		currentLot: {
+			lotId: '',
+			inProgress: false,
+		},
 		paymentInformation: {},
 		drivingInformation: { canDrive: false },
 		myDriverLotHistory: driverLotHistoryId,

--- a/public/style.js
+++ b/public/style.js
@@ -99,13 +99,6 @@ module.exports = StyleSheet.create({
 		width: React.Dimensions.get('window').width * .9,
 		margin: 30,
 	},
-	buttonRows: {
-		flexDirection: 'row',
-		flexWrap: 'nowrap',
-		justifyContent: 'space-between',
-		// marginBottom: 100,
-		// bottom: -100,
-	},
 
 	/**
 	 * Style for Matchbanner
@@ -202,23 +195,6 @@ module.exports = StyleSheet.create({
 		backgroundColor: BROFFWHITE,
 		height: React.Dimensions.get('window').height,
 	},
-	horizontalRule: {
-		marginLeft: 15,
-		marginRight: 15,
-		borderBottomColor: 'black',
-		borderBottomWidth: 1,
-		margin: 3,
-	},
-	center: {
-		alignSelf: 'center',
-		alignItems: 'center',
-	},
-	webView: {
-		marginTop: 20,
-	},
-	webOuterView: {
-		flex: 1
-	},
 	button: {
 		backgroundColor: BRBLUE,
 		width: React.Dimensions.get('window').width * .9,
@@ -226,8 +202,30 @@ module.exports = StyleSheet.create({
 		justifyContent: 'center',
 		alignSelf: 'center'
 	},
+	buttonRows: {
+		flexDirection: 'row',
+		flexWrap: 'nowrap',
+		justifyContent: 'space-between',
+	},
 	buttonText: {
 		color: BROFFWHITE,
+	},
+	center: {
+		alignSelf: 'center',
+		alignItems: 'center',
+	},
+	horizontalRule: {
+		marginLeft: 15,
+		marginRight: 15,
+		borderBottomColor: 'black',
+		borderBottomWidth: 1,
+		margin: 3,
+	},
+	webView: {
+		marginTop: 20,
+	},
+	webOuterView: {
+		flex: 1
 	},
 	backButton: {
 		marginLeft: 10,


### PR DESCRIPTION
1. Made a change to the way that Firestore Users documents are structured: `currentLot` is now an object, rather than a string. It has two properties: one is `lotId`, which holds the string of the lot's id (this is what `currentLot` originally was); the other is `inProgress`, which distinguishes between lots in which bidding is still open (ie, the timer is still going), and ones in which the lot has moved to `lot_history` in Firestore, but the trip itself is happening (which is the case during the time in which the driver is on the way to the passenger and while they are making the trip itself).
2. Fixed deleting lots, so that doing so no longer breaks MainScreen.
3. Using (1), MatchBanner should now display differently while a trip is in progress (though not different between when a Driver is on the way vs. there)
4. Other minor updates. To style, also, updated (hopefully) all of the files that would have been broken by (1)